### PR TITLE
Add macOS Sierra template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,14 @@ MAC_OSX_10_8_MOUNTAIN_LION_INSTALLER ?= iso/OS\ X\ Mountain\ Lion/Install\ OS\ X
 MAC_OSX_10_9_MAVERICKS_INSTALLER ?= iso/OS\ X\ Mavericks/Install\ OS\ X\ Mavericks.app
 MAC_OSX_10_10_YOSEMITE_INSTALLER ?= iso/Install\ OS\ X\ Yosemite.app
 MAC_OSX_10_11_EL_CAPITAN_INSTALLER ?= iso/Install\ OS\ X\ El\ Capitan.app
+MAC_OSX_10_12_SIERRA_INSTALLER ?= iso/Install\ macOS\ Sierra.app
 
 MAC_OSX_10_7_LION_BOOT_DMG ?= $(notdir $(firstword $(wildcard dmg/OSX_InstallESD_10.7*) ))
 MAC_OSX_10_8_MOUNTAIN_LION_BOOT_DMG ?= $(notdir $(firstword $(wildcard dmg/OSX_InstallESD_10.8*) ))
 MAC_OSX_10_9_MAVERICKS_BOOT_DMG ?= $(notdir $(firstword $(wildcard dmg/OSX_InstallESD_10.9*) ))
 MAC_OSX_10_10_YOSEMITE_BOOT_DMG ?= $(notdir $(firstword $(wildcard dmg/OSX_InstallESD_10.10*) ))
 MAC_OSX_10_11_EL_CAPITAN_BOOT_DMG ?= $(notdir $(firstword $(wildcard dmg/OSX_InstallESD_10.11*) ))
+MAC_OSX_10_12_SIERRA_BOOT_DMG ?= $(notdir $(firstword $(wildcard dmg/OSX_InstallESD_10.12*) ))
 
 # Possible values for CM: (nocm | chef | chefdk | salt | puppet)
 CM ?= nocm
@@ -148,6 +150,20 @@ dmg/$(MAC_OSX_10_11_EL_CAPITAN_BOOT_DMG): $(MAC_OSX_10_11_EL_CAPITAN_INSTALLER)
 	mkdir -p dmg
 	sudo prepare_iso/prepare_iso.sh $(MAC_OSX_10_11_EL_CAPITAN_INSTALLER) dmg
 
+dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG): $(MAC_OSX_10_12_SIERRA_INSTALLER)
+	mkdir -p dmg
+	sudo prepare_iso/prepare_iso.sh $(MAC_OSX_10_12_SIERRA_INSTALLER) dmg
+
+$(VMWARE_BOX_DIR)/osx1012$(BOX_SUFFIX): osx1012.json $(SOURCES) dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)
+	rm -rf $(VMWARE_OUTPUT)
+	mkdir -p $(VMWARE_BOX_DIR)
+	$(PACKER) build -only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)" -var-file=$< osx.json
+
+$(VMWARE_BOX_DIR)/osx1012-desktop$(BOX_SUFFIX): osx1012-desktop.json $(SOURCES) tpl/vagrantfile-osx1011-desktop.tpl dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)
+	rm -rf $(VMWARE_OUTPUT)
+	mkdir -p $(VMWARE_BOX_DIR)
+	$(PACKER) build -only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)" -var-file=$< osx.json
+
 $(VMWARE_BOX_DIR)/osx1011$(BOX_SUFFIX): osx1011.json $(SOURCES) dmg/$(MAC_OSX_10_11_EL_CAPITAN_BOOT_DMG)
 	rm -rf $(VMWARE_OUTPUT)
 	mkdir -p $(VMWARE_BOX_DIR)
@@ -198,6 +214,16 @@ $(VMWARE_BOX_DIR)/osx107-desktop$(BOX_SUFFIX): osx107-desktop.json $(SOURCES) tp
 	mkdir -p $(VMWARE_BOX_DIR)
 	$(PACKER) build -only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=dmg/$(MAC_OSX_10_7_LION_BOOT_DMG)" $<
 
+$(VIRTUALBOX_BOX_DIR)/osx1012$(BOX_SUFFIX): osx1012.json $(SOURCES) dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)
+	rm -rf $(VIRTUALBOX_OUTPUT)
+	mkdir -p $(VIRTUALBOX_BOX_DIR)
+	$(PACKER) build -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)" $<
+
+$(VIRTUALBOX_BOX_DIR)/osx1012-desktop$(BOX_SUFFIX): osx1012-desktop.json $(SOURCES) tpl/vagrantfile-osx1011-desktop.tpl dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)
+	rm -rf $(VIRTUALBOX_OUTPUT)
+	mkdir -p $(VIRTUALBOX_BOX_DIR)
+	$(PACKER) build -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)" $<
+
 $(VIRTUALBOX_BOX_DIR)/osx1011$(BOX_SUFFIX): osx1011.json $(SOURCES) dmg/$(MAC_OSX_10_11_EL_CAPITAN_BOOT_DMG)
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
@@ -247,6 +273,16 @@ $(VIRTUALBOX_BOX_DIR)/osx107-desktop$(BOX_SUFFIX): osx107-desktop.json $(SOURCES
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
 	$(PACKER) build -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=dmg/$(MAC_OSX_10_7_LION_BOOT_DMG)" $<
+
+$(PARALLELS_BOX_DIR)/osx1012$(BOX_SUFFIX): osx1012.json $(SOURCES) dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	$(PACKER) build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)" $<
+
+$(PARALLELS_BOX_DIR)/osx1012-desktop$(BOX_SUFFIX): osx1012-desktop.json $(SOURCES) tpl/vagrantfile-osx1011-desktop.tpl dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	$(PACKER) build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=dmg/$(MAC_OSX_10_12_SIERRA_BOOT_DMG)" $<
 
 $(PARALLELS_BOX_DIR)/osx1011$(BOX_SUFFIX): osx1011.json $(SOURCES) dmg/$(MAC_OSX_10_11_EL_CAPITAN_BOOT_DMG)
 	rm -rf $(PARALLELS_OUTPUT)

--- a/osx1012-desktop.json
+++ b/osx1012-desktop.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Build with `packer build -var-file=osx1012-desktop.json osx.json`",
+  "vm_name": "osx1012-desktop",
+  "desktop": "true",
+  "cpus": "1",
+  "disk_size": "62536",
+  "iso_url": "dmg/OSX_InstallESD_10.12_16A323.dmg",
+  "memory": "4096",
+  "parallels_guest_os_type": "win-8",
+  "vagrantfile_template": "tpl/vagrantfile-osx1012-desktop.tpl",
+  "virtualbox_guest_os_type": "MacOS1012_64",
+  "vmware_guest_os_type": "darwin16-64"
+}

--- a/osx1012.json
+++ b/osx1012.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Build with `packer build -var-file=osx1012.json osx.json`",
+  "vm_name": "osx1012",
+  "desktop": "false",
+  "cpus": "1",
+  "disk_size": "64000",
+  "iso_url": "dmg/OSX_InstallESD_10.12_16A323.dmg",
+  "memory": "4096",
+  "parallels_guest_os_type": "win-8",
+  "vagrantfile_template": "",
+  "virtualbox_guest_os_type": "MacOS1012_64",
+  "vmware_guest_os_type": "darwin16-64"
+}

--- a/tpl/vagrantfile-osx1012-desktop.tpl
+++ b/tpl/vagrantfile-osx1012-desktop.tpl
@@ -1,0 +1,51 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.define "vagrant-osx1012-desktop"
+    config.vm.box = "osx1012-desktop"
+
+    ["vmware_fusion", "vmware_workstation"].each do |provider|
+        config.vm.provider provider do |v, override|
+            v.gui = true
+            v.vmx["memsize"] = "2048"
+            v.vmx["numvcpus"] = "1"
+            v.vmx["firmware"] = "efi"
+            v.vmx["keyboardAndMouseProfile"] = "macProfile"
+            v.vmx["smc.present"] = "TRUE"
+            v.vmx["hpet0.present"] = "TRUE"
+            v.vmx["ich7m.present"] = "TRUE"
+            v.vmx["ehci.present"] = "TRUE"
+            v.vmx["usb.present"] = "TRUE"
+            v.vmx["scsi0.virtualDev"] = "lsilogic"
+        end
+    end
+
+    config.vm.provider :virtualbox do |v, override|
+      v.gui = true
+      v.customize ["modifyvm", :id, "--audiocontroller", "hda"]
+      v.customize ["modifyvm", :id, "--boot1", "dvd"]
+      v.customize ["modifyvm", :id, "--boot2", "disk"]
+      v.customize ["modifyvm", :id, "--chipset", "ich9"]
+      v.customize ["modifyvm", :id, "--firmware", "efi"]
+      v.customize ["modifyvm", :id, "--hpet", "on"]
+      v.customize ["modifyvm", :id, "--keyboard", "usb"]
+      v.customize ["modifyvm", :id, "--memory", "2048"]
+      v.customize ["modifyvm", :id, "--mouse", "usbtablet"]
+      v.customize ["modifyvm", :id, "--vram", "128"]
+    end
+
+    config.vm.provider :parallels do |v, override|
+      v.customize ["set", :id, "--memsize", "2048"]
+      v.customize ["set", :id, "--memquota", "512:2048"]
+      v.customize ["set", :id, "--cpus", "2"]
+      v.customize ["set", :id, "--distribution", "macosx"]
+      v.customize ["set", :id, "--3d-accelerate", "highest"]
+      v.customize ["set", :id, "--high-resolution", "off"]
+      v.customize ["set", :id, "--auto-share-camera", "off"]
+      v.customize ["set", :id, "--auto-share-bluetooth", "off"]
+      v.customize ["set", :id, "--on-window-close", "keep-running"]
+      v.customize ["set", :id, "--isolate-vm", "off"]
+      v.customize ["set", :id, "--shf-host", "off"]
+    end
+end


### PR DESCRIPTION
As nobody else has started a PR for this, here is a template for macOS Sierra.

I have used the `Makefile` with `make vmware/osx1012-desktop` but had problems that packer with the missing osx.json. I've added the missing parts to the osx1012 targets. Please let me know if I'm on the right way then I can update the for other targets as well, probably in another PR.
