### PR TITLE
fix typo in softwareupdate command: '-verbose' -> '--verbose'

### DIFF
--- a/script/update.sh
+++ b/script/update.sh
@@ -6,7 +6,7 @@ defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabl
 if [[ "$UPDATE" =~ ^(true|yes|on|1|TRUE|YES|ON])$ ]]; then
 
     echo "==> Running software update"
-    softwareupdate --install --all -verbose
+    softwareupdate --install --all --verbose
 
     echo "==> Rebooting the machine"
     reboot


### PR DESCRIPTION
The missing hyphen causes verbose to be interpreted as several incorrect options.
