### PR TITLE
Fix syntax errors in energy provisioner

### DIFF
--- a/script/energy.sh
+++ b/script/energy.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-echo ==> 'Disabling screensaver'
+echo "==> 'Disabling screensaver'"
 defaults -currentHost write com.apple.screensaver idleTime 0
-echo ==> 'Turning off energy saving'
+echo "==> 'Turning off energy saving'"
 pmset -a displaysleep 0 disksleep 0 sleep 0
 # https://carlashley.com/2016/10/19/com-apple-touristd/
-echo ==> 'Disable New to Mac notification'
+echo "==> 'Disable New to Mac notification'"
 defaults write com.apple.touristd seed-https://help.apple.com/osx/mac/10.12/whats-new -date "$(date)"


### PR DESCRIPTION
Previously, those echo lines would write `==` to a file in the user's home folder. That appears to be unintended behavior.