### PR TITLE
Disable login screensaver & complete when older vmware tools fails install

### DIFF
--- a/script/energy.sh
+++ b/script/energy.sh
@@ -2,6 +2,8 @@
 
 echo "==> 'Disabling screensaver'"
 defaults -currentHost write com.apple.screensaver idleTime 0
+echo "==> 'Disabling login screensaver'"
+defaults -currentHost write com.apple.screensaver loginWindowIdleTime 0
 echo "==> 'Turning off energy saving'"
 pmset -a displaysleep 0 disksleep 0 sleep 0
 # https://carlashley.com/2016/10/19/com-apple-touristd/

--- a/script/minimize.sh
+++ b/script/minimize.sh
@@ -24,5 +24,7 @@ diskutil secureErase freespace 0 ${slash}
 # VMware Fusion specific items
 if [ -e .vmfusion_version ] || [[ "$PACKER_BUILDER_TYPE" == vmware* ]]; then
     # Shrink the disk
-    /Library/Application\ Support/VMware\ Tools/vmware-tools-cli disk shrink /
+    if [ -e /Library/Application\ Support/VMware\ Tools/vmware-tools-cli ]; then
+        /Library/Application\ Support/VMware\ Tools/vmware-tools-cli disk shrink /
+    fi
 fi


### PR DESCRIPTION
Although by default the boxcutter VM built will auto login and simply disabling the user screen saver can be enough, however in some cases the use may invoke the login screen on the VM.  When this occurs the screen saver may start and waist resources.

Also the latest versions of VMware products ship with `darwin.iso` tools that are only compatible with 10.11 or greater.  In this case when `minimize.sh` attempt to shink the volume it fails causing the entire build to abort.  A check is added to allow build completion when `vmware-tools-cli` is not found.

```
    vmware-iso: Installing VMware tools..
    vmware-iso: installer: Cannot install on volume / because it is disabled.
    vmware-iso: installer: OS X version 10.11 or later is required.
```