### PR TITLE
disable the install user's screensaver

### DIFF
--- a/script/energy.sh
+++ b/script/energy.sh
@@ -2,6 +2,7 @@
 
 echo "==> 'Disabling screensaver'"
 defaults -currentHost write com.apple.screensaver idleTime 0
+su $SSH_USERNAME -c "defaults -currentHost write com.apple.screensaver idleTime 0"
 echo "==> 'Disabling login screensaver'"
 defaults -currentHost write com.apple.screensaver loginWindowIdleTime 0
 echo "==> 'Turning off energy saving'"


### PR DESCRIPTION
Since the energy settings are applied after the install user has been created and logged in, the timeout for that user needs to explicitly set.