### PR TITLE
Use tail instead of head

### DIFF
--- a/script/xcode-cli-tools.sh
+++ b/script/xcode-cli-tools.sh
@@ -9,7 +9,7 @@ if [ "$OSX_VERS" -ge 9 ]; then
     # in Apple's SUS catalog
     touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
     # find the CLI Tools update
-    PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    PROD=$(softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
     # install it
     softwareupdate -i "$PROD" --verbose
     rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress


### PR DESCRIPTION
WIP:
- [ ] add test
 
In the script to install the Command Line Tools, using `head` picks up the first result, often a older and unwanted version.

Example: 
```
$ softwareupdate -l |  grep "\*.*Command Line"
   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2
   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3
   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4
   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4
```

In the above, with the current setup, the 10.11 version will be selected (and downloaded) which will result in unpredictable behaviour.

Using `tail -n 1` does the right thing.